### PR TITLE
[Main Page] IH 메인 레이아웃 개선

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom'
 
 import SearchLayout from './components/layouts/SearchLayout'
-import SearchMainPage from './components/pages/SearchMainPage'
 import SearchListPage from './components/pages/SearchListPage'
 import GameDetailPage from './components/pages/GameDetailPage'
 
@@ -11,12 +10,11 @@ class Router extends Component {
     return (
       <BrowserRouter>
         <Switch>
-          {/* 검색바는 모든 페이지에서 사용됨 */}
           <Route render={
             (props) => (
               <SearchLayout {...props}>
                 <Switch>
-                  <Route exact path="/" component={SearchMainPage} />
+                  <Route exact path="/"/>
                   <Route exact path="/search" component={SearchListPage} />
                   <Route exact path="/detail" component={GameDetailPage} />
                   <Redirect to="/" />

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -3,6 +3,7 @@ import styled, { css, keyframes } from 'styled-components'
 import { withRouter } from 'react-router-dom'
 import {
   DropDown,
+  StyledInput,
 } from '../../styled/ui-components'
 
 class SearchLayout extends Component {
@@ -170,21 +171,7 @@ const SearchIcon = styled.div`
   color: gray;
   opacity: 0.8;
 `
-const Input = styled.input`
-  width: 800px;
-  height: 50px;
-  padding-left: 20px;
-  border-radius: 30px;
-  border: unset;
-  color: #FFFFFF;
-  display: flex;
-  background: #000000;
-  ${itemCenter};
-  :focus {
-    outline: none;
-  }
-`
-const SearchInput = styled(Input)`
+const SearchInput = styled(StyledInput)`
   font-size: 20px;
   font-weight: 300;
   padding-right: 20px;

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -146,10 +146,9 @@ const slideUpNav = keyframes`
   0% {
     opacity: 20%;
     height: 100vh;
-    transform: translate(0px, 0px);
+    transform: translate(0px, -50vh);
   }
   100% {
-    height: 7vh;
     transform: translate(0px, -100vh);
   }
 `
@@ -169,7 +168,6 @@ const NavBar = styled.div`
 const slideFadeUpLogo = keyframes`
   from {
     opacity: 0;
-    transform: translate(0px, 0px);
   }
   to {
     opacity: 1;
@@ -195,11 +193,9 @@ const fadeIn = keyframes`
 `
 const slideUpSearchBar = keyframes`
   0% {
-    height: 100vh;
-    transform: translate(0px, 50vh);
+    transform: translate(0px, 100vh);
   }
   100% {
-    height: 100vh;
     transform: translate(0px, 100vh);
   }
 `

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -59,15 +59,15 @@ class SearchLayout extends Component {
   }
 
   onKeyUp (e) {
-    if (e.keyCode === 13) {
+    let { inputValue } = this.state
+    if (e.keyCode === 13 && inputValue.trim() !== '') {
       //  TODO: 검색 API 연동
-      const path = '/search'
-      this.props.history.push(path)
+      this.props.history.push('/search')
     }
   }
 
   render () {
-    let { placeholder, inputValue, isMain, deviceList } = this.state
+    let { placeholder, inputValue, isMain } = this.state
 
     return (
       <StyledSearchLayout isMain={ isMain }>
@@ -94,7 +94,7 @@ class SearchLayout extends Component {
       </StyledSearchLayout>
     )
   }
-
+  // TODO: 드롭다운 UI 컴포넌트 분리
   renderDeviceDropDown () {
     const currentPath = this.props.location.pathname
     let { deviceList } = this.state
@@ -147,7 +147,6 @@ const StyledSearchLayout = styled.div`
     `}
   ${itemCenter}
 `
-
 const NavBar = styled.div`
   display: flex;
   background-color: #000000;
@@ -157,7 +156,6 @@ const NavBar = styled.div`
       ${itemCenter}
     `}
 `
-
 const Logo = styled.div`
   color: #FFFFFF;
   font-weight: 300;

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -91,9 +91,7 @@ class SearchLayout extends Component {
             Scan Games
           </Logo>
           <SearchBar isMain={ isMain }>
-            <SearchIcon>
-              <i className="fa fa-2x fa-search"></i>
-            </SearchIcon>
+            <SearchIcon isMain={ isMain } />
             <SearchInput
               placeholder={ placeholder }
               ref={(input) => { this.searchInputRef = input }}
@@ -215,13 +213,23 @@ const SearchBar = styled.div`
         animation: ${slideUpSearchBar} 1.5s ease-in-out;
       `} 
 `
-const SearchIcon = styled.div`
+//  TODO: 아이콘 태그를 styled-component에서 어떻게 쓰는지 아래 주소를 참고했는데, 개선이 필요합니다.
+//  https://stackoverflow.com/questions/48607218/styled-components-how-to-display-an-icon
+const Icon = (props) => {
+  //  NOTE: ${props.className} 를 꼭 보내야 화면에 렌더된다고 합니다.
+  return <i className={`fa fa-2x fa-search ${props.className}`}></i>
+}
+const SearchIcon = styled(Icon)`
   display: flex;
   ${itemCenter}
   padding-left: 10px;
   padding-right: 10px;
   color: gray;
   opacity: 0.8;
+  ${({ isMain }) => isMain === false &&
+    css`
+      animation: ${slideUpSearchBar} 1.5s ease-in-out;
+    `}
 `
 const SearchInput = styled(StyledInput)`
   font-size: 20px;

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -39,10 +39,14 @@ class SearchLayout extends Component {
   }
 
   detectCurrentPath () {
-    const currentPath = this.props.location.pathname
-    this.setState({
-      isMain: currentPath === '/',
-    })
+    let { location } = this.props
+    const currentPath = location.pathname
+    let isMain = false
+    //  NOTE: 최초 렌더시에는 props.location의 state값이 ud이다.
+    if (location.state === undefined) {
+      isMain = currentPath === '/'
+    }
+    this.setState({ isMain })
   }
 
   componentDidUpdate (prevProps) {
@@ -67,7 +71,13 @@ class SearchLayout extends Component {
     let { inputValue } = this.state
     if (e.keyCode === 13 && inputValue.trim() !== '') {
       //  TODO: 검색 API 연동
-      this.props.history.push('/search')
+      this.props.history.push({
+        pathname: '/search',
+        state: {
+          //  TODO: 각 페이지에서 라우트 이동시 이전 페이지 path 넘기기
+          prevPath: this.props.location.pathname
+        }
+      })
     }
   }
 
@@ -158,14 +168,26 @@ const NavBar = styled.div`
       `} 
   } 
 `
+const slideFadeUpLogo = keyframes`
+  from {
+    opacity: 0;
+    transform: translate(0px, 0px);
+  }
+  to {
+    opacity: 1;
+  }
+`
 const Logo = styled.div`
   color: #FFFFFF;
   font-weight: 300;
   font-size: 3rem;
-  ${({ isMain }) => isMain && 
-    css`
-      top: 30vh;
-      position: absolute;
+  ${({ isMain }) => isMain
+    ? css`
+        top: 30vh;
+        position: absolute;
+      `
+    : css`
+      animation: ${slideFadeUpLogo} 4s ease-in-out;
     `}
 `
 const fadeIn = keyframes`

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -9,6 +9,17 @@ class SearchLayout extends Component {
       inputValue: '',
       placeholder: 'scan.games 검색',
       isMain: false,
+      deviceList: [
+        {
+          name: 'desktop',
+        },
+        {
+          name: 'switch',
+        },
+        {
+          name: 'mobile',
+        },
+      ],
     }
     this.renderContent = this.renderContent.bind(this)
     this.onChangeSearch = this.onChangeSearch.bind(this)
@@ -56,7 +67,7 @@ class SearchLayout extends Component {
   }
 
   render () {
-    let { placeholder, inputValue, isMain } = this.state
+    let { placeholder, inputValue, isMain, deviceList } = this.state
 
     return (
       <StyledSearchLayout isMain={ isMain }>
@@ -69,6 +80,7 @@ class SearchLayout extends Component {
               <i className="fa fa-2x fa-search"></i>
             </SearchIcon>
             <SearchInput
+              isMain={ isMain }
               placeholder={ placeholder }
               ref={(input) => { this.searchInputRef = input }}
               type="search"
@@ -76,15 +88,41 @@ class SearchLayout extends Component {
               onChange={ (e) => this.onChangeSearch(e) }
               onKeyUp={ (e) => this.onKeyUp(e) }/>
           </SearchBar>
+          { this.renderDeviceDropDown() }
         </NavBar>
         { this.renderContent() }
       </StyledSearchLayout>
     )
   }
 
-  renderContent () {
+  renderDeviceDropDown () {
     const currentPath = this.props.location.pathname
-    if (currentPath === '/') return
+    let { deviceList } = this.state
+    if (currentPath !== '/detail') return
+
+    return (
+      <DropDownContainer isDetail={ currentPath === '/detail' }>
+        <DropDownIcon>
+          <i className="fa fa-2x fa-desktop"></i>
+        </DropDownIcon>
+        <DropDownContent>
+          {
+            deviceList.map((device, index) => (
+              <DeviceContent key={ index }>
+                <DeviceName href="#">
+                  { device.name }
+                </DeviceName>
+              </DeviceContent>
+            ))
+          }
+        </DropDownContent>
+      </DropDownContainer>
+    )
+  }
+
+  renderContent () {
+    const { isMain } = this.state
+    if (isMain) return
 
     return (
       <ContentSection>
@@ -112,19 +150,20 @@ const StyledSearchLayout = styled.div`
 
 const NavBar = styled.div`
   display: flex;
+  background-color: #000000;
   ${({ isMain }) => isMain && 
     css`
+      background-color: unset;
       ${itemCenter}
     `}
 `
 
 const Logo = styled.div`
-  color: #000000;
+  color: #FFFFFF;
   font-weight: 300;
   font-size: 3rem;
   ${({ isMain }) => isMain && 
     css`
-      color: #FFFFFF;
       top: 30vh;
       position: absolute;
     `}
@@ -152,9 +191,9 @@ const Input = styled.input`
   padding-left: 20px;
   border-radius: 30px;
   border: unset;
-  color: black;
-  background: #ffffff;
+  color: #FFFFFF;
   display: flex;
+  background: #000000;
   ${itemCenter};
   :focus {
     outline: none;
@@ -164,9 +203,57 @@ const SearchInput = styled(Input)`
   font-size: 20px;
   font-weight: 300;
   padding-right: 20px;
+  margin-top: 5px;
+  margin-bottom: 5px;
   ::placeholder {
     color: #6E6E73;
   }
+  ${({ isMain }) => isMain && 
+    css`
+      background: #FFFFFF;
+      color: unset;
+    `}
+`
+
+const DropDownIcon = styled.div`
+  color: gray;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+const DropDownContent = styled.div`
+  display: none;
+  position: absolute;
+  background-color: #FFFFFF;
+  min-width: 160px;
+  border-radius: 18px;
+`
+const DropDownContainer = styled.div`
+  position: relative;
+  display: inline-block;
+  margin: auto;
+  &: hover ${DropDownContent} {
+    display: block;
+  }
+  &: hover ${DropDownIcon} {
+    color: #FFFFFF;
+  }
+`
+const DeviceContent = styled.div`
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  border-top: 1px solid #d2d2d7;
+  &: hover a {
+    text-decoration: underline;
+  }
+  &: first-child {
+    border-top-style: none;
+  }
+`
+const DeviceName = styled.a`
+  text-decoration: none;
+  color: #000000;
 `
 
 const ContentSection = styled.div`

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -80,12 +80,11 @@ class SearchLayout extends Component {
           <Logo isMain={ isMain }>
             Scan Games
           </Logo>
-          <SearchBar>
+          <SearchBar isMain={ isMain }>
             <SearchIcon>
               <i className="fa fa-2x fa-search"></i>
             </SearchIcon>
             <SearchInput
-              isMain={ isMain }
               placeholder={ placeholder }
               ref={(input) => { this.searchInputRef = input }}
               type="search"
@@ -124,25 +123,40 @@ const itemCenter = css`
   justify-content: center;
   align-items: center;
 `
-const mainBackgroundImg = 'https://i.picsum.photos/id/366/1700/900.jpg'
 const StyledSearchLayout = styled.div`
-  ${({ isMain }) => isMain && 
+  ${({ isMain }) => isMain &&
     css`
-      height: 100vh;
       display: flex;
       flex-direction: column;
-      background-image: url(${mainBackgroundImg});
-    `}
+    `
+  }
+  background: #2D485B;
+  height: 100vh;
   ${itemCenter}
+`
+const slideUpNav = keyframes`
+  0% {
+    opacity: 20%;
+    height: 100vh;
+    transform: translate(0px, 0px);
+  }
+  100% {
+    height: 7vh;
+    transform: translate(0px, -100vh);
+  }
 `
 const NavBar = styled.div`
   display: flex;
-  background-color: #000000;
-  ${({ isMain }) => isMain && 
-    css`
-      background-color: unset;
-      ${itemCenter}
-    `}
+  background: #2D485B;
+  height: 7vh;
+  ${({ isMain }) => isMain
+    ? css`
+        ${itemCenter}
+      `
+    : css`
+        animation: ${slideUpNav} 1.5s ease-in-out;
+      `} 
+  } 
 `
 const Logo = styled.div`
   color: #FFFFFF;
@@ -154,14 +168,30 @@ const Logo = styled.div`
       position: absolute;
     `}
 `
-const slideFade = keyframes`
+const fadeIn = keyframes`
   from {
     opacity: 20%;
   }
 `
+const slideUpSearchBar = keyframes`
+  0% {
+    height: 100vh;
+    transform: translate(0px, 50vh);
+  }
+  100% {
+    height: 100vh;
+    transform: translate(0px, 100vh);
+  }
+`
 const SearchBar = styled.div`
   display: flex;
-  animation: ${slideFade} 1.2s ease-in-out;
+  ${({ isMain }) => isMain
+    ? css`
+        animation: ${fadeIn} 1s ease-in-out;
+      `
+    : css`
+        animation: ${slideUpSearchBar} 1.5s ease-in-out;
+      `} 
 `
 const SearchIcon = styled.div`
   display: flex;
@@ -180,16 +210,22 @@ const SearchInput = styled(StyledInput)`
   ::placeholder {
     color: #6E6E73;
   }
-  ${({ isMain }) => isMain && 
-    css`
-      background: #FFFFFF;
-      color: unset;
-    `}
+  background: #FFFFFF;
+  color: #000000;
+`
+const slideUpContent = keyframes`
+  from {
+    opacity: 0%;
+  }
+  to {
+    opacity: 100%;
+  }
 `
 const ContentSection = styled.div`
   border: 1px solid black;
   background-color: lightgray;
-  min-height: 50vh;
+  height: 93vh;
+  animation: ${slideUpContent} 1.5s ease-in-out;
 `
 
 export default withRouter(SearchLayout)

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -213,13 +213,7 @@ const SearchBar = styled.div`
         animation: ${slideUpSearchBar} 1.5s ease-in-out;
       `} 
 `
-//  TODO: 아이콘 태그를 styled-component에서 어떻게 쓰는지 아래 주소를 참고했는데, 개선이 필요합니다.
-//  https://stackoverflow.com/questions/48607218/styled-components-how-to-display-an-icon
-const Icon = (props) => {
-  //  NOTE: ${props.className} 를 꼭 보내야 화면에 렌더된다고 합니다.
-  return <i className={`fa fa-2x fa-search ${props.className}`}></i>
-}
-const SearchIcon = styled(Icon)`
+const SearchIcon = styled.i.attrs({ className: 'fa fa-2x fa-search' })`
   display: flex;
   ${itemCenter}
   padding-left: 10px;

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -7,25 +7,37 @@ class SearchLayout extends Component {
     super(props)
     this.state = {
       inputValue: '',
-      placeholder: 'scan.games 검색'
+      placeholder: 'scan.games 검색',
+      isMain: false,
     }
     this.renderContent = this.renderContent.bind(this)
     this.onChangeSearch = this.onChangeSearch.bind(this)
     this.onKeyUp = this.onKeyUp.bind(this)
+    this.detectCurrentPath = this.detectCurrentPath.bind(this)
   }
 
   componentDidMount () {
     if (this.searchInputRef) {
       this.searchInputRef.focus()
     }
+    this.detectCurrentPath()
+  }
+
+  detectCurrentPath () {
+    const currentPath = this.props.location.pathname
+    this.setState({
+      isMain: currentPath === '/',
+    })
   }
 
   componentDidUpdate (prevProps) {
-    if (this.props !== prevProps &&
-        this.props.location.pathname === '/') {
-      this.setState({
-        inputValue: '',
-      })
+    if (this.props !== prevProps) {
+      if (this.props.location.pathname === '/') {
+        this.setState({
+          inputValue: '',
+        })
+      }
+      this.detectCurrentPath()
     }
   }
 
@@ -44,26 +56,27 @@ class SearchLayout extends Component {
   }
 
   render () {
-    let { placeholder, inputValue } = this.state
-    const currentPath = this.props.location.pathname
+    let { placeholder, inputValue, isMain } = this.state
+
     return (
-      <StyledSearchLayout isMain={ currentPath === '/' }>
-        <Logo isMain={ currentPath === '/' }>
-          Scan Gamesss
-        </Logo>
-        <SearchBar>
-          <SearchIcon>
-            <i className="fa fa-2x fa-search"></i>
-          </SearchIcon>
-          <SearchInput
-            placeholder={ placeholder }
-            ref={(input) => { this.searchInputRef = input }}
-            type="text"
-            value={ inputValue }
-            onChange={(e) => this.onChangeSearch(e)}
-            onKeyUp={(e) => this.onKeyUp(e)}/>
-        </SearchBar>
-        {/* 예시) 상위 컴포넌트인 App.js에서 정의한 fade-in 클래스 사용 */}
+      <StyledSearchLayout isMain={ isMain }>
+        <NavBar isMain={ isMain }>
+          <Logo isMain={ isMain }>
+            Scan Games
+          </Logo>
+          <SearchBar>
+            <SearchIcon>
+              <i className="fa fa-2x fa-search"></i>
+            </SearchIcon>
+            <SearchInput
+              placeholder={ placeholder }
+              ref={(input) => { this.searchInputRef = input }}
+              type="text"
+              value={ inputValue }
+              onChange={ (e) => this.onChangeSearch(e) }
+              onKeyUp={ (e) => this.onKeyUp(e) }/>
+          </SearchBar>
+        </NavBar>
         { this.renderContent() }
       </StyledSearchLayout>
     )
@@ -97,12 +110,24 @@ const StyledSearchLayout = styled.div`
   ${itemCenter}
 `
 
+const NavBar = styled.div`
+  display: flex;
+  ${({ isMain }) => isMain && 
+    css`
+      ${itemCenter}
+    `}
+`
+
 const Logo = styled.div`
-  color: #FFFFFF;
+  color: #000000;
   font-weight: 300;
   font-size: 3rem;
-  position: absolute;
-  top: 30vh;
+  ${({ isMain }) => isMain && 
+    css`
+      color: #FFFFFF;
+      top: 30vh;
+      position: absolute;
+    `}
 `
 const slideFade = keyframes`
   from {
@@ -116,6 +141,7 @@ const SearchBar = styled.div`
 const SearchIcon = styled.div`
   display: flex;
   ${itemCenter}
+  padding-left: 10px;
   padding-right: 10px;
   color: gray;
   opacity: 0.8;
@@ -131,7 +157,7 @@ const Input = styled.input`
   display: flex;
   ${itemCenter};
   :focus {
-    outline:none;
+    outline: none;
   }
 `
 const SearchInput = styled(Input)`

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 import { withRouter } from "react-router-dom"
 
 class SearchLayout extends Component {
@@ -48,6 +48,9 @@ class SearchLayout extends Component {
     const currentPath = this.props.location.pathname
     return (
       <StyledSearchLayout isMain={ currentPath === '/' }>
+        <Logo isMain={ currentPath === '/' }>
+          Scan Gamesss
+        </Logo>
         <SearchBar>
           <SearchIcon>
             <i className="fa fa-2x fa-search"></i>
@@ -82,18 +85,33 @@ const itemCenter = css`
   justify-content: center;
   align-items: center;
 `
-
+const mainBackgroundImg = 'https://i.picsum.photos/id/366/1700/900.jpg'
 const StyledSearchLayout = styled.div`
-  ${(props) => props.isMain && ({
-    background: '#2D485B',
-    height: '100vh',
-    display: 'flex',
-  })}
+  ${({ isMain }) => isMain && 
+    css`
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background-image: url(${mainBackgroundImg});
+    `}
   ${itemCenter}
 `
 
+const Logo = styled.div`
+  color: #FFFFFF;
+  font-weight: 300;
+  font-size: 3rem;
+  position: absolute;
+  top: 30vh;
+`
+const slideFade = keyframes`
+  from {
+    opacity: 20%;
+  }
+`
 const SearchBar = styled.div`
   display: flex;
+  animation: ${slideFade} 1.2s ease-in-out;
 `
 const SearchIcon = styled.div`
   display: flex;

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -71,7 +71,7 @@ class SearchLayout extends Component {
             <SearchInput
               placeholder={ placeholder }
               ref={(input) => { this.searchInputRef = input }}
-              type="text"
+              type="search"
               value={ inputValue }
               onChange={ (e) => this.onChangeSearch(e) }
               onKeyUp={ (e) => this.onKeyUp(e) }/>
@@ -163,6 +163,7 @@ const Input = styled.input`
 const SearchInput = styled(Input)`
   font-size: 20px;
   font-weight: 300;
+  padding-right: 20px;
   ::placeholder {
     color: #6E6E73;
   }

--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
 import styled, { css, keyframes } from 'styled-components'
-import { withRouter } from "react-router-dom"
+import { withRouter } from 'react-router-dom'
+import {
+  DropDown,
+} from '../../styled/ui-components'
 
 class SearchLayout extends Component {
   constructor(props) {
@@ -43,7 +46,8 @@ class SearchLayout extends Component {
 
   componentDidUpdate (prevProps) {
     if (this.props !== prevProps) {
-      if (this.props.location.pathname === '/') {
+      const currentPath = this.props.location.pathname
+      if (currentPath === '/') {
         this.setState({
           inputValue: '',
         })
@@ -94,30 +98,13 @@ class SearchLayout extends Component {
       </StyledSearchLayout>
     )
   }
-  // TODO: 드롭다운 UI 컴포넌트 분리
+
   renderDeviceDropDown () {
     const currentPath = this.props.location.pathname
-    let { deviceList } = this.state
     if (currentPath !== '/detail') return
+    let { deviceList } = this.state
 
-    return (
-      <DropDownContainer isDetail={ currentPath === '/detail' }>
-        <DropDownIcon>
-          <i className="fa fa-2x fa-desktop"></i>
-        </DropDownIcon>
-        <DropDownContent>
-          {
-            deviceList.map((device, index) => (
-              <DeviceContent key={ index }>
-                <DeviceName href="#">
-                  { device.name }
-                </DeviceName>
-              </DeviceContent>
-            ))
-          }
-        </DropDownContent>
-      </DropDownContainer>
-    )
+    return <DropDown contentList={ deviceList } />
   }
 
   renderContent () {
@@ -212,48 +199,6 @@ const SearchInput = styled(Input)`
       color: unset;
     `}
 `
-
-const DropDownIcon = styled.div`
-  color: gray;
-  margin-top: 10px;
-  margin-bottom: 10px;
-`
-const DropDownContent = styled.div`
-  display: none;
-  position: absolute;
-  background-color: #FFFFFF;
-  min-width: 160px;
-  border-radius: 18px;
-`
-const DropDownContainer = styled.div`
-  position: relative;
-  display: inline-block;
-  margin: auto;
-  &: hover ${DropDownContent} {
-    display: block;
-  }
-  &: hover ${DropDownIcon} {
-    color: #FFFFFF;
-  }
-`
-const DeviceContent = styled.div`
-  color: black;
-  padding: 12px 16px;
-  text-decoration: none;
-  display: block;
-  border-top: 1px solid #d2d2d7;
-  &: hover a {
-    text-decoration: underline;
-  }
-  &: first-child {
-    border-top-style: none;
-  }
-`
-const DeviceName = styled.a`
-  text-decoration: none;
-  color: #000000;
-`
-
 const ContentSection = styled.div`
   border: 1px solid black;
   background-color: lightgray;

--- a/src/components/pages/SearchMainPage/index.js
+++ b/src/components/pages/SearchMainPage/index.js
@@ -1,9 +1,0 @@
-import React, { Component } from 'react'
-
-class SearchMainPage extends Component {
-  render () {
-    return <>메인 페이지 입니다.</>
-  }
-}
-
-export default SearchMainPage

--- a/src/components/styled/ui-components/DropDown/index.js
+++ b/src/components/styled/ui-components/DropDown/index.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types';
+
+const propType = {
+  contentList: PropTypes.array.isRequired,
+}
+
+class DropDown extends Component {
+
+  render () {
+    let { contentList } = this.props
+    return (
+      <DropDownContainer>
+        {/* TODO: 드롭다운 아이콘 dynamic 변경 */}
+        <DropDownIcon>
+          <i className="fa fa-2x fa-desktop"></i>
+        </DropDownIcon>
+        <DropDownContent>
+          {
+            contentList.map((content, index) => (
+              <Content key={ index }>
+                <ContentName>
+                  { content.name }
+                </ContentName>
+              </Content>
+            ))
+          }
+        </DropDownContent>
+      </DropDownContainer>
+    )
+  }
+}
+
+const DropDownIcon = styled.div`
+  color: gray;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+const DropDownContent = styled.div`
+  display: none;
+  position: absolute;
+  background-color: #FFFFFF;
+  min-width: 160px;
+  border-radius: 18px;
+`
+const DropDownContainer = styled.div`
+  position: relative;
+  display: inline-block;
+  margin: auto;
+  &: hover ${DropDownContent} {
+    display: block;
+  }
+  &: hover ${DropDownIcon} {
+    color: #FFFFFF;
+  }
+`
+const Content = styled.div`
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  border-top: 1px solid #d2d2d7;
+  &: hover a {
+    text-decoration: underline;
+  }
+  &: first-child {
+    border-top-style: none;
+  }
+`
+const ContentName = styled.a`
+  cursor: pointer;
+  text-decoration: none;
+  color: #000000;
+`
+
+DropDown.propTypes = propType
+
+DropDown.defaultProps = {
+  contentList: [],
+}
+
+export default DropDown

--- a/src/components/styled/ui-components/StyledInput/index.js
+++ b/src/components/styled/ui-components/StyledInput/index.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+export const StyledInput = styled.input`
+  width: 800px;
+  height: 50px;
+  padding-left: 20px;
+  border-radius: 30px;
+  border: unset;
+  color: #FFFFFF;
+  display: flex;
+  background: #000000;
+  justify-content: center;
+  align-items: center;
+  :focus {
+    outline: none;
+  }
+`

--- a/src/components/styled/ui-components/index.js
+++ b/src/components/styled/ui-components/index.js
@@ -1,5 +1,7 @@
 import { StyledCard } from './StyledCard'
+import DropDown from './DropDown'
 
 export {
   StyledCard,
+  DropDown,
 }

--- a/src/components/styled/ui-components/index.js
+++ b/src/components/styled/ui-components/index.js
@@ -1,7 +1,9 @@
 import { StyledCard } from './StyledCard'
 import DropDown from './DropDown'
+import { StyledInput } from './StyledInput'
 
 export {
   StyledCard,
   DropDown,
+  StyledInput,
 }


### PR DESCRIPTION
[주요 변경점]
- 메인, 서치 페이지 이동 시 애니메이션 추가
- 디테일 페이지에서 상단 바에 드롭 다운 추가 (서치페이지에서 디테일로 라우트 변경시 prevPath를 넘겨주셔야 애니메이션이 디테일에서는 동작하지 않습니다. 라우트 이동 구현시 추가하면 될 것 같습니다. 아래 공유 사항을 참고해주세요.)
- dropdown 컴포넌트 분리
- StyledInput 컴포넌트 분리

[공유 사항]
- 이전 path를 기억해서 애니메이션을 동작할지 말지 결정하고 싶은데, 라우트 이동시 this.props.location.state에 prevPath와 같이 현재 path를 저장하도록 했는데, 이렇게 되면 라우트 이동시마다 현재 path를 저장해줘야하는 불편함이 있는 것 같습니다. 어떻게 개선할 수 있는지 고민이 필요합니다.
- style-component에 바인딩 되지 않은 tag들은 animation이 제대로 동작하지 않더라구요. 그래서 icon 태그랑 바인딩 어떻게 하는지 찾아봤는데(https://stackoverflow.com/questions/48607218/styled-components-how-to-display-an-icon), 흠.. 이해가 가지 않지만 저렇게 해야 동작해야 한다고 하는데 어떻게 하면 좋을지 찾아봐야할 것 같습니다.