### PR TITLE
[YG] 패딩을 ContentSection에서 각 컴포넌트로 옮김

### DIFF
--- a/src/components/layouts/SearchLayout/index.js
+++ b/src/components/layouts/SearchLayout/index.js
@@ -250,9 +250,8 @@ const slideUpContent = keyframes`
 const ContentSection = styled.div`
   position: relative;
   background-color: whitesmoke;
-  height: 85vh;
+  height: 93vh;
   overflow: auto;
-  padding: 4vh 15%;
   animation: ${slideUpContent} 1.5s ease-in-out;
 `
 

--- a/src/components/pages/SearchListPage/index.js
+++ b/src/components/pages/SearchListPage/index.js
@@ -133,6 +133,7 @@ class SearchListPage extends Component {
 const SearchListContainer = styled.div`
   display: flex;
   flex-direction: column;
+  margin: 4vh 15%;
 `
 
 const SearchCount = styled.div`


### PR DESCRIPTION
## 작업 내용
 - fix: ContentSection에서 패딩 없애고 하위 컴포넌트에서 마진 주도록 처리

## 스크린샷
- Before
![image](https://user-images.githubusercontent.com/6694664/82137674-25ada300-9855-11ea-99d3-0033527bd7c2.png)

- After
![image](https://user-images.githubusercontent.com/6694664/82137683-36f6af80-9855-11ea-8135-332ad53a5de5.png)
